### PR TITLE
Removing duplicate hidden field for project_id. 

### DIFF
--- a/app/views/donations/_form.html.erb
+++ b/app/views/donations/_form.html.erb
@@ -64,8 +64,6 @@
 
   </div>
 
-  <%= f.hidden_field :project_id %>
-
   <% if logged_in? %>
     <%= f.hidden_field :user_id, :value => current_user.id %>
   <% end %>


### PR DESCRIPTION
This issue fixes issue #18

There was a duplicate "project_id" hidden field that was sending a blank project_id and raising a validation error on creation. The correct project_id hidden field seems to already be at the beginning of the form
