### PR TITLE
Hacky solution to 'create project from autocomplete'

### DIFF
--- a/app/assets/javascripts/general.js.coffee
+++ b/app/assets/javascripts/general.js.coffee
@@ -1,6 +1,3 @@
-$( "#donation_project_name" ).autocomplete
-  source: [ "c++", "java", "php", "coldfusion", "javascript", "asp", "ruby" ]
-
 $(document).on "page:change", ->
   $(".popup").click (event) ->
     event.preventDefault()
@@ -9,5 +6,3 @@ $(document).on "page:change", ->
   $('.tipsit').tipsy({fade: true; gravity: 's'})
   my_slidebars = new $.slidebars();
   return
-
-

--- a/app/assets/javascripts/pages.js.coffee
+++ b/app/assets/javascripts/pages.js.coffee
@@ -1,5 +1,12 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
-
+project_name = new String()
+$(document).on "page:change", ->
   
+  $('#donation_project_name').on 'keyup', ->
+    project_name = $(this).val()
+  
+  $('#donation_project_name').bind 'railsAutocomplete.select', (event, data) =>
+    if data.item.id is ''
+      window.location = '/projects/new?name=' + project_name

--- a/app/views/donations/_form.html.erb
+++ b/app/views/donations/_form.html.erb
@@ -10,7 +10,7 @@
           <%= @project.name %>
         </div>
       <% else %>
-        <%= f.autocomplete_field :project_name, autocomplete_project_name_projects_path, :id_element => '#donation_project_id',  placeholder: 'Project', :"data-autocomplete-label" => "Sorry, nothing found." %>
+        <%= f.autocomplete_field :project_name, autocomplete_project_name_projects_path, :id_element => '#donation_project_id',  placeholder: 'Project', :'data-autocomplete-label' => 'Add this project...' %>
       <% end %>
 
       <% if params[:controller] == 'projects' %> 
@@ -56,10 +56,6 @@
       </div>
       
     </div>
-
-    <!-- <div>
-      <label><input type="checkbox" name="i_want_to_keep_private"> <%= t 'i_want_to_keep_private' %></label>
-    </div> -->
 
   </div>
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -9,7 +9,6 @@
 				<li><%= t 'main_bullet_3' %></li>
 			</ul>
       <%= link_to t('read_more_about_this_project'), {controller: 'pages', action: 'about'}, class: 'button' %>
-      <%# link_to t('read_more_about_this_project'), class: 'button' %>
 
 		</section>
 
@@ -31,10 +30,7 @@
 					<% end %>
 				</header>
 
-				<%# form_for :donation, url: donations_path, html: {class: "simple_form"} do |f| %>
-        <%# form_for :donation, url: donations_path do |f| %>
-          <%= render 'donations/form' %>
-        <%# end %>
+        <%= render 'donations/form' %>
 
 			</div>
 

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -23,7 +23,7 @@
 
     <p>
       <%= f.label(:name, t('project')) %><br>
-      <%= f.autocomplete_field :name, autocomplete_project_name_projects_path %>
+      <%= f.autocomplete_field :name, autocomplete_project_name_projects_path, :value => params[:name] %>
     </p>
    
     <p>


### PR DESCRIPTION
Check out this pull request (but don't merge it just yet...) If we'd solve the problem of the javascript (for some reason) not picking up the label 'Add new project...', this would sort of work. Try entering a 'Wadus' kind of name and then select the 'no existing matches' option.

I'm not very fond of this gem, to be honest. It doesn't respect the restful conventions and it is quite limited in options - we would eventually have to modify their javascript, which is generally not a good idea. I'd be more inclined to use something like [Select2](http://ivaynberg.github.io/select2/) which is highly configurable and we can do whatever we want with it in terms of behaviour. 

(By the way, I've just realized that I automatically removed some commented or old code that I should have done elsewhere - don't worry about that)
