### PR TITLE
Modal for signin/signup/social login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'bourbon'
 group :development, :test do
   gem 'spring'
   gem 'byebug'
+  gem 'jasmine'
 end
 
 group :test do
@@ -56,7 +57,6 @@ group :test do
   gem 'launchy'
   gem 'email_spec'
   gem 'timecop'
-  gem 'jasmine'
 end
 
 group :development do

--- a/app/assets/javascripts/general.js
+++ b/app/assets/javascripts/general.js
@@ -17,7 +17,8 @@
 
     $('[data-behaviour=datepicker]').pikaday({
       firstDay: 1,
-      i18n: I18n.t("date.picker")
+      i18n: I18n.t("date.picker"),
+      maxDate: new Date()
     });
   }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -371,7 +371,6 @@ body.projects_index {
   }*/
 
   #unfollow_button {
-    width: 88px;
     text-align: center;
   }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,7 +42,8 @@ class ApplicationController < ActionController::Base
           cookies.delete(:donation) if cookies[:donation]
           redirect_to donation_path(@donation, share_links: true)
         else
-          render 'donations/new'
+          flash[:error] = t('.error_creating_donation', errors: @donation.errors.full_messages.to_sentence)
+          redirect_to(:back)
         end
       else
         recurring_donation = current_user.recurring_donations.build(donation_params.merge(project: project))
@@ -53,7 +54,8 @@ class ApplicationController < ActionController::Base
           redirect_to donation_path(donation, share_links: true)
         else
           @donation = Donation.new(attributes: recurring_donation.attributes.except('frequency_period', 'frequency_units', 'finished_at'))
-          render 'donations/new'
+          flash[:error] = t('.error_creating_donation', errors: recurring_donation.errors.full_messages.to_sentence)
+          redirect_to(:back)
         end
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,8 +32,8 @@ class ApplicationController < ActionController::Base
     end
 
     def save_donation(donation_params)
-      if donation_params[:project_id]
-        project = Project.find_by(id: donation_params[:project_id])
+      if donation_params[:project_attributes] && donation_params[:project_attributes][:id]
+        project = Project.find_by(id: donation_params[:project_attributes][:id])
       end
 
       if donation_params[:recurring] == 'no'
@@ -47,14 +47,12 @@ class ApplicationController < ActionController::Base
       else
         recurring_donation = current_user.recurring_donations.build(donation_params.merge(project: project))
         if recurring_donation.save
-          if donation = recurring_donation.donations.sorted.last
-            redirect_to donation_path(donation, share_links: true)
-          else
-            flash[:success] = "Donación recurrente creada correctamente. TrackDons registrará automáticamente las donaciones futuras"
-            redirect_to(:back)
-          end
+          # TODO: we redirect to the last donation created in the recurring donation
+          #       We could probably show information about the recurring donation
+          donation = recurring_donation.donations.sorted.last
+          redirect_to donation_path(donation, share_links: true)
         else
-          @donation = recurring_donation
+          @donation = Donation.new(attributes: recurring_donation.attributes.except('frequency_period', 'frequency_units', 'finished_at'))
           render 'donations/new'
         end
       end

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -42,7 +42,7 @@ class DonationsController < ApplicationController
   private
 
   def donation_params
-    params.require(:donation).permit(:quantity, :currency, :date, :comment, :quantity_privacy, :show_comment,
+    params.require(:donation).permit(:quantity, :currency, :date, :comment, :quantity_privacy, :show_comment, :recurring,
                                      :project_id, project_attributes: [:name, :description, :url, :id, :category_id])
   end
 

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -19,6 +19,8 @@ class Donation < ActiveRecord::Base
   validates :user_id, presence: true
   validates :date, presence: true
 
+  validate :date_is_not_in_the_future
+
   before_validation :set_project, :clear_comment
 
   def show_comment
@@ -46,6 +48,12 @@ class Donation < ActiveRecord::Base
         self.project = Project.create_with({
           description: self.project.description,
           url: self.project.url}).find_or_create_by(name: self.project.name)
+      end
+    end
+
+    def date_is_not_in_the_future
+      if self.date && self.date > Date.today
+        errors.add(:date, :invalid)
       end
     end
 

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -1,13 +1,12 @@
 class Donation < ActiveRecord::Base
 
   belongs_to :project, counter_cache: true
-  accepts_nested_attributes_for :project
-
   belongs_to :user, counter_cache: true
-
   belongs_to :recurring_donation
 
-  before_validation :set_project, :clear_comment
+  attr_accessor :recurring
+
+  accepts_nested_attributes_for :project
 
   monetize :quantity_cents, as: :quantity, with_model_currency: :currency
 
@@ -20,13 +19,7 @@ class Donation < ActiveRecord::Base
   validates :user_id, presence: true
   validates :date, presence: true
 
-  def set_project
-    if self.project && self.project.new_record?
-      self.project = Project.create_with({
-        description: self.project.description,
-        url: self.project.url}).find_or_create_by(name: self.project.name)
-    end
-  end
+  before_validation :set_project, :clear_comment
 
   def show_comment
     comment.present?
@@ -45,6 +38,14 @@ class Donation < ActiveRecord::Base
     def clear_comment
       if @show_comment == '0'
         self.comment = nil
+      end
+    end
+
+    def set_project
+      if self.project && self.project.new_record?
+        self.project = Project.create_with({
+          description: self.project.description,
+          url: self.project.url}).find_or_create_by(name: self.project.name)
       end
     end
 

--- a/app/models/recurring_donation.rb
+++ b/app/models/recurring_donation.rb
@@ -13,6 +13,7 @@ class RecurringDonation < ActiveRecord::Base
   validates :quantity_cents, presence: true
   validates :frequency_units, presence: true, numericality: true
   validates :frequency_period, presence: true, inclusion: { in: %W{ day days month months year years week weeks } }
+  validate :date_is_not_in_the_future
 
   before_validation :set_frequency, :set_project
   after_create { create_pending_donations }
@@ -96,6 +97,12 @@ class RecurringDonation < ActiveRecord::Base
       self.project = Project.create_with({
         description: self.project.description,
         url: self.project.url}).find_or_create_by(name: self.project.name)
+    end
+  end
+
+  def date_is_not_in_the_future
+    if self.date && self.date > Date.today
+      errors.add(:date, :invalid)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ActiveRecord::Base
   has_secure_password validations: false
 
   has_many :donations, dependent: :destroy
+  has_many :recurring_donations, dependent: :destroy
   has_many :projects, through: :donations
   has_many :invitations
 

--- a/app/views/donations/_form.html.erb
+++ b/app/views/donations/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(donation_for_form, url: (@project ? project_donations_path(@project) : donations_path)) do |f| %>
+<%= form_for(donation_for_form) do |f| %>
 
   <div class="bb-donations" data-projects="<%= projects_path %>">
     <div class="js-donations mb1">
@@ -12,10 +12,10 @@
                   <%= project_form.label(:name, I18n.t('donation.project')) %>
                 </div>
                 <div class="form-fields">
-                  <% if new_donation? %>
-                    <%= project_form.text_field :name, :class => "hundred percent js-select2" %>
-                  <% else %>
+                  <% if @project %>
                     <%= project_form.text_field :name, :class => "hundred percent field-text", :disabled => true %>
+                  <% else %>
+                    <%= project_form.text_field :name, :class => "hundred percent js-select2" %>
                   <% end %>
                 </div>
               <% end %>
@@ -41,7 +41,7 @@
             </div>
             <div class="form-fields">
               <div class="field-select field-group-item">
-                <select class="js-donation-reurring" name="donation[recurring]" value="<%= f.object.recurring %>">
+                <select class="js-donation-reurring" name="donation[recurring]" value="<%= f.object.recurring %>" id="donation_recurring">
                   <option value="no" selected="selected">No</option>
                   <option value="daily"><%= t('.daily') %></option>
                   <option value="weekly"><%= t('.weekly') %></option>
@@ -76,7 +76,6 @@
               <%= f.label(:quantity_privacy, 'Yes') %>
             </div>
           </div>
-
         </div>
 
         <div class="js-details donation-details mt2 justify-item hundred percent">

--- a/app/views/donations/_form.html.erb
+++ b/app/views/donations/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(donation_for_form, url: (@project ? project_donations_path : donations_path)) do |f| %>
+<%= form_for(donation_for_form, url: (@project ? project_donations_path(@project) : donations_path)) do |f| %>
 
   <div class="bb-donations" data-projects="<%= projects_path %>">
     <div class="js-donations mb1">
@@ -41,7 +41,7 @@
             </div>
             <div class="form-fields">
               <div class="field-select field-group-item">
-                <select class="js-donation-reurring" name="donation[recurring]" value="<%= f.object.recurring %>>
+                <select class="js-donation-reurring" name="donation[recurring]" value="<%= f.object.recurring %>">
                   <option value="no" selected="selected">No</option>
                   <option value="daily"><%= t('.daily') %></option>
                   <option value="weekly"><%= t('.weekly') %></option>

--- a/app/views/donations/_form.html.erb
+++ b/app/views/donations/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(donation_for_form) do |f| %>
+<%= form_for(donation_for_form, url: (@project ? project_donations_path : donations_path)) do |f| %>
 
   <div class="bb-donations" data-projects="<%= projects_path %>">
     <div class="js-donations mb1">
@@ -18,9 +18,8 @@
                     <%= project_form.text_field :name, :class => "hundred percent field-text", :disabled => true %>
                   <% end %>
                 </div>
-              <% end %>          
+              <% end %>
             </div>
-            <!-- <h2><%# t('.edit_your_donation', name: @project.name) %></h2> -->
 
           <div class="form-group justify-item">
             <div class="form-label uppercase">
@@ -42,18 +41,18 @@
             </div>
             <div class="form-fields">
               <div class="field-select field-group-item">
-                <select class="js-donation-reurring" name="donation[recurring]">
+                <select class="js-donation-reurring" name="donation[recurring]" value="<%= f.object.recurring %>>
                   <option value="no" selected="selected">No</option>
-                  <option value="daily">Daily</option>
-                  <option value="weekly">Weekly</option>
-                  <option value="2 weeks">2 Weeks</option>
-                  <option value="3 weeks">3 Weeks</option>
-                  <option value="monthly">Monthly</option>
-                  <option value="2 months">2 Months</option>
-                  <option value="3 months">3 Months</option>
-                  <option value="4 months">4 Months</option>
-                  <option value="6 months">6 Months</option>
-                  <option value="12 months">12 Months</option>
+                  <option value="daily"><%= t('.daily') %></option>
+                  <option value="weekly"><%= t('.weekly') %></option>
+                  <option value="2 weeks"><%= t('.weeks', n: 2) %></option>
+                  <option value="3 weeks"><%= t('.weeks', n: 3) %></option>
+                  <option value="monthly"><%= t('.monthly') %></option>
+                  <option value="2 months"><%= t('.months', n: 2) %></option>
+                  <option value="3 months"><%= t('.months', n: 3) %></option>
+                  <option value="4 months"><%= t('.months', n: 4) %></option>
+                  <option value="6 months"><%= t('.months', n: 6) %></option>
+                  <option value="12 months"><%= t('.months', n: 12) %></option>
                 </select>
               </div>
             </div>
@@ -61,7 +60,7 @@
 
           <div class="form-group justify-item">
             <div class="form-label uppercase">
-              <%= f.label(:date, t('donation.date'), :class => 'js-donation-date') %> 
+              <%= f.label(:date, t('donation.date'), :class => 'js-donation-date') %>
             </div>
             <div class="form-fields">
               <%= f.text_field :date, :placeholder => t('donation.pick_date'), :class => "donation-date field-text", :data => {:behaviour => "datepicker"} %>
@@ -70,16 +69,16 @@
 
           <div class="form-group justify-item">
             <div class="form-label uppercase">
-              <%= f.label(:quantity_privacy, t('donation.private'), :title => t('donations.form.quantity_privacy_hint'), :class => 'tipsit') %> 
+              <%= f.label(:quantity_privacy, t('donation.private'), :title => t('donations.form.quantity_privacy_hint'), :class => 'tipsit') %>
             </div>
             <div class="form-fields solid">
               <%= f.check_box :quantity_privacy %>
-              <%= f.label(:quantity_privacy, 'Yes') %> 
+              <%= f.label(:quantity_privacy, 'Yes') %>
             </div>
           </div>
 
         </div>
-        
+
         <div class="js-details donation-details mt2 justify-item hundred percent">
           <%= f.fields_for(:project) do |project_form| %>
             <%= project_form.text_area :description, :placeholder => t('donation.description'), :class => "field-textarea hundred percent mb2" %>
@@ -91,6 +90,7 @@
 
     </div>
 
+    <% # Temporary disabled %>
     <% if false && !new_donation? %>
       <div id="add-donation" class="js-add-donation s11 mb3">
         <a href="#"><%= I18n.t('donation.add') %></a>
@@ -104,6 +104,7 @@
   <% end %>
 
   <%= f.submit(donation_form_button_text, class: 'big mb4' ) %>
+
   <% if editing_donation? %>
     <%= link_to(t('.cancel'), @donation) %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,6 +93,8 @@ en:
       monthly: Monthly
       weeks: "%{n} weeks"
       months: "%{n} months"
+    create:
+      error_creating_donation: "Donation couldn't be created: %{errors}"
 
   # donations form
   how_much_question: 'How much?'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,14 @@ en:
           attributes:
             countries:
               invalid: "must contain a valid name of country"
+        donation:
+          attributes:
+            date:
+              invalid: "must be today or previous to today"
+        recurring_donation:
+          attributes:
+            date:
+              invalid: "must be today or previous to today"
   language_name: "English"
   hello: "Hello world"
   # generics

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,11 @@ en:
       cancel: Cancel
       edit_your_donation: Edit your donation to the project %{name}
       quantity_privacy_hint: "Don't be shy sharing the quantity. Everyone donates what they can / feels is right. So even a penny would be good. On the other hand, it would be fun to study how individual behaviours influence others... for good or for bad!"
+      daily: Daily
+      weekly: Weekly
+      monthly: Monthly
+      weeks: "%{n} weeks"
+      months: "%{n} months"
 
   # donations form
   how_much_question: 'How much?'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -112,7 +112,11 @@ es:
       cancel: Cancelar
       edit_your_donation: Edita tu donación al proyecto %{name}
       quantity_privacy_hint: "No seas tímido compartiendo la cantidad. Todo el mundo dona lo que quiere o siente que es correcto. Incluso un céntimo sería bueno. Por otro lado sería divertido estudiar cómo el compartamiento de uno afecta a los demás... ¡para bueno o para malo!"
-  # donaciones form
+      daily: Diario
+      weekly: Semanal
+      monthly: Mensual
+      weeks: "%{n} semanas"
+      months: "%{n} meses"
   how_much_question: '¿Cuánto?'
   when_did_you_donate: '¿Cuándo donaste?'
   i_want_to_explain_why: 'Quiero explicar por qué he donado para animar a otros'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -131,6 +131,8 @@ es:
       monthly: Mensual
       weeks: "%{n} semanas"
       months: "%{n} meses"
+    create:
+      error_creating_donation: "No se pudo crear la donación: %{errors}"
   how_much_question: '¿Cuánto?'
   when_did_you_donate: '¿Cuándo donaste?'
   i_want_to_explain_why: 'Quiero explicar por qué he donado para animar a otros'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -8,6 +8,14 @@ es:
           attributes:
             countries:
               invalid: "tiene que contener nombres válidos de país"
+        donation:
+          attributes:
+            date:
+              invalid: "tiene que ser hoy o anterior a hoy"
+        recurring_donation:
+          attributes:
+            date:
+              invalid: "tiene que ser hoy o anterior a hoy"
     models:
       user: Usuario
       invitation: Invitación
@@ -39,6 +47,12 @@ es:
         currency: Moneda
         user_id: Usuario
         comment: Comentario
+      recurring_donation:
+        date: Fecha
+        project_id: Proyecto
+        quantity: Cantidad
+        currency: Moneda
+        user_id: Usuario
   language_name: 'Español'
   hello: "Hello world"
   # generics

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,9 +24,11 @@ Rails.application.routes.draw do
     resources :users, except: [:new]
 
     resources :donations
+    resources :recurring_donations, only: [:new, :create]
 
     resources :projects do
       resources :donations
+      resources :recurring_donations, only: [:new, :create]
       member do
         patch 'follow'
         patch 'unfollow'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,11 +24,9 @@ Rails.application.routes.draw do
     resources :users, except: [:new]
 
     resources :donations
-    resources :recurring_donations, only: [:new, :create]
 
     resources :projects do
       resources :donations
-      resources :recurring_donations, only: [:new, :create]
       member do
         patch 'follow'
         patch 'unfollow'

--- a/db/migrate/20150315074845_rename_starts_at_column.rb
+++ b/db/migrate/20150315074845_rename_starts_at_column.rb
@@ -1,0 +1,5 @@
+class RenameStartsAtColumn < ActiveRecord::Migration
+  def change
+    rename_column :recurring_donations, :started_at, :date
+  end
+end

--- a/db/migrate/20150315075047_add_quantity_privacy.rb
+++ b/db/migrate/20150315075047_add_quantity_privacy.rb
@@ -1,0 +1,5 @@
+class AddQuantityPrivacy < ActiveRecord::Migration
+  def change
+    add_column :recurring_donations, :quantity_privacy, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150226175510) do
+ActiveRecord::Schema.define(version: 20150315075047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,16 +110,17 @@ ActiveRecord::Schema.define(version: 20150226175510) do
   add_index "projects", ["slug"], name: "index_projects_on_slug", using: :btree
 
   create_table "recurring_donations", force: :cascade do |t|
-    t.integer  "user_id",          null: false
-    t.integer  "project_id",       null: false
-    t.integer  "quantity_cents",   null: false
-    t.string   "currency",         null: false
-    t.integer  "frequency_units",  null: false
-    t.string   "frequency_period", null: false
-    t.date     "started_at",       null: false
+    t.integer  "user_id",                          null: false
+    t.integer  "project_id",                       null: false
+    t.integer  "quantity_cents",                   null: false
+    t.string   "currency",                         null: false
+    t.integer  "frequency_units",                  null: false
+    t.string   "frequency_period",                 null: false
+    t.date     "date",                             null: false
     t.date     "finished_at"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+    t.boolean  "quantity_privacy", default: false
   end
 
   create_table "taggings", force: :cascade do |t|

--- a/spec/features/create_recurring_donations_spec.rb
+++ b/spec/features/create_recurring_donations_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.feature 'Create recurring donations' do
+  background do
+    Timecop.freeze Time.parse('2014-10-30')
+
+    @project = create_project(name: 'Wikiwadus')
+    @user = create_user(name: 'Yorch', password: 'wadusm4n', email: "yorch@example.com")
+  end
+
+  scenario 'I see a success page and message' do
+    login_as "yorch@example.com", "wadusm4n"
+
+    visit projects_page
+
+    click_link('Wikiwadus')
+
+    fill_in 'donation_date', :with => "2014-10-10"
+    fill_in 'donation_quantity', :with => "200.99"
+    select '$', from: 'donation_currency'
+    select '2 weeks', from: 'donation_recurring'
+    click_button 'TrackDon'
+
+    expect(page).to have_content 'Great, your donation is tracked. This is just the beginning.'
+    expect(page).to have_content '$200.99 to Wikiwadus by Yorch'
+
+    # TODO: once we redirect to a nice page that shows recurring donation information
+    #       we'll be able to get rid of this check
+    donation = Donation.last
+    expect(donation.recurring_donation).to be_present
+  end
+end

--- a/spec/features/creating_project_while_tracking_don_spec.rb
+++ b/spec/features/creating_project_while_tracking_don_spec.rb
@@ -13,11 +13,11 @@ RSpec.feature 'Adding projects while tracking donations. When I create a donatio
 
     find('#donation_project_attributes_name').set 'Ngrok'
 
-    fill_in 'Project Description', :with => 'Introspected tunnels to localhost'
-    fill_in 'URL', :with => 'https://ngrok.com/'
+    fill_in 'donation_project_attributes_description', :with => 'Introspected tunnels to localhost'
+    fill_in 'donation_project_attributes_url', :with => 'https://ngrok.com/'
 
-    fill_in 'When did you donate?', :with => '2014-10-10'
-    fill_in 'How much?', :with => '25'
+    fill_in 'Date', :with => '2014-10-10'
+    fill_in 'Amount', :with => '25'
 
     click_button 'TrackDon'
 

--- a/spec/features/creating_projects_spec.rb
+++ b/spec/features/creating_projects_spec.rb
@@ -25,12 +25,5 @@ RSpec.feature 'Creating projects' do
     expect(page).to have_content('Rubular')
     expect(page).to have_content('rubular.com')
     expect(page).to have_css('a', text: '@rubular')
-
-    fill_in 'donation_date', :with => "2014-10-10"
-    fill_in 'donation_quantity', :with => "200"
-    click_button 'TrackDon'
-
-    expect(page).to have_content 'Great, your donation is tracked. This is just the beginning.'
-    expect(page).to have_content '200€ to Rubular by Yorch'
   end
 end

--- a/spec/features/user_donations_spec.rb
+++ b/spec/features/user_donations_spec.rb
@@ -65,13 +65,11 @@ RSpec.feature 'User donations' do
       click_link('Edit')
     end
 
-    fill_in 'How much?', :with => '25'
-    fill_in 'When did you donate?', :with => '2013-10-10'
-    uncheck 'i_want_to_explain'
+    fill_in 'Amount', :with => '25'
+    fill_in 'Date', :with => '2013-10-10'
     click_button 'Update'
 
     expect(page).to have_css('h1', text: 'Wikiwadus')
-    expect(page).to_not have_content('This is my comment')
 
     visit user_page(@user)
 

--- a/spec/models/recurring_donation_spec.rb
+++ b/spec/models/recurring_donation_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe RecurringDonation, type: :model do
 
     context 'when no donation exist' do
       it 'should create the donations for today date' do
-        expect(project.donations.count).to be(0)
+        project.donations.clear
 
         described_class.create_today_donations
 
@@ -69,7 +69,7 @@ RSpec.describe RecurringDonation, type: :model do
 
     context 'when donations already exist' do
       it 'should not create any duplicated donation' do
-        expect(project.donations.count).to be(0)
+        project.donations.clear
 
         described_class.create_today_donations
 
@@ -86,6 +86,7 @@ RSpec.describe RecurringDonation, type: :model do
     context "when recurring donation date date is a day that don't exist in all months" do
       it 'should create the donations' do
         Timecop.freeze Time.parse('2015-2-28')
+        project.donations.clear
 
         expect(project.donations.count).to be(0)
 

--- a/spec/models/recurring_donation_spec.rb
+++ b/spec/models/recurring_donation_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RecurringDonation, type: :model do
     it 'should calculate the next donation date' do
       recurring_donation = create_recurring_donation({
         frequency_units: 3, frequency_period: 'months',
-        started_at: Date.parse('2014-1-1')
+        date: Date.parse('2014-1-1')
       })
 
       expect(recurring_donation.next_donation_date).to eq(Date.parse('2015-4-1'))
@@ -23,7 +23,7 @@ RSpec.describe RecurringDonation, type: :model do
 
       recurring_donation = create_recurring_donation({
         frequency_units: 1, frequency_period: 'months',
-        started_at: Date.parse('2014-12-31')
+        date: Date.parse('2014-12-31')
       })
 
       expect(recurring_donation.next_donation_date).to eq(Date.parse('2015-1-31'))
@@ -34,7 +34,7 @@ RSpec.describe RecurringDonation, type: :model do
 
       recurring_donation = create_recurring_donation({
         frequency_units: 1, frequency_period: 'months',
-        started_at: Date.parse('2014-12-31')
+        date: Date.parse('2014-12-31')
       })
 
       expect(recurring_donation.next_donation_date).to eq(Date.parse('2015-2-28'))
@@ -46,7 +46,7 @@ RSpec.describe RecurringDonation, type: :model do
       create_recurring_donation({
         user: user, project: project, quantity: 30, currency: 'EUR',
         frequency_units: 1, frequency_period: 'months',
-        started_at: Date.parse('2014-12-30')
+        date: Date.parse('2014-12-30')
       })
     end
 
@@ -83,7 +83,7 @@ RSpec.describe RecurringDonation, type: :model do
       end
     end
 
-    context "when recurring donation started_at date is a day that don't exist in all months" do
+    context "when recurring donation date date is a day that don't exist in all months" do
       it 'should create the donations' do
         Timecop.freeze Time.parse('2015-2-28')
 

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -43,7 +43,7 @@ module Factories
     attrs[:project]          ||= create_project
     attrs[:quantity]         ||= 10
     attrs[:currency]         ||= 'EUR'
-    attrs[:started_at]       ||= Date.today - 7.days
+    attrs[:date]             ||= Date.today - 7.days
     attrs[:frequency_units]  ||= 1
     attrs[:frequency_period] ||= 'year'
     RecurringDonation.create!(attrs)


### PR DESCRIPTION
This addresses #112. Be ware that the new js/css is a bit of a mess :S (I guess I should be doing these things ;) But it seems it works.

Pending that I'm aware of

- [x] Cleanup old forms (sign in, signup, recover password). I guess we could get rid of them, but we should 
- [x] If you fire the modal, fill email+pass for login, and hit enter, you get shown another form; it should just submit the form
- [ ] In the header we have two links (signup, login), the two do the same, we could unify in one

@ferblape as I said, I think I forked this from the right branch so we have all recent improvements. 