### PR TITLE
Fixes issue #141: Project list 'sort by' links not working once selected

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -31,7 +31,7 @@ module ProjectsHelper
     filters << [:country, country] if country
     filters.flatten!
 
-    extra_params.merge!({sort_by: params[:sort_by]}) if params[:sort_by]
+    extra_params.merge!({sort_by: params[:sort_by]}) if !extra_params[:sort_by] && params[:sort_by]
 
     url_params = {}
     url_params.merge!({filters: filters}) if filters.any?

--- a/spec/features/projects_navigation_spec.rb
+++ b/spec/features/projects_navigation_spec.rb
@@ -24,9 +24,9 @@ RSpec.feature 'Projects navigation' do
 
     click_link "Latest"
 
-    expect(page).to have_css(".project:nth-child(2) a", text: "Cruz Roja")
+    expect(page).to have_css(".project:nth-child(2) a", text: "Wikipedia")
     expect(page).to have_css(".project:nth-child(3) a", text: "Médicos Sin Fronteras")
-    expect(page).to have_css(".project:nth-child(4) a", text: "Wikipedia")
+    expect(page).to have_css(".project:nth-child(4) a", text: "Cruz Roja")
   end
 
   scenario 'I should be able to filter by Category' do

--- a/spec/features/projects_navigation_spec.rb
+++ b/spec/features/projects_navigation_spec.rb
@@ -4,9 +4,18 @@ RSpec.feature 'Projects navigation' do
   background do
     health = create_category(name: 'Health')
 
-    create_project name: 'Cruz Roja', category: health, countries: ['US', 'ES']
-    create_project name: 'Médicos Sin Fronteras', category: health, countries: ['ES']
-    create_project name: 'Wikipedia', countries: ['ES']
+    @user = create_user(name: 'Marlo', email: "marlo@muchachada.nui")
+
+    @other_user = create_user(name: 'Claudio', email: "claudio@muchachada.nui")
+
+    @cruz_roja = create_project name: 'Cruz Roja', category: health, countries: ['US', 'ES']
+    @medicos = create_project name: 'Médicos Sin Fronteras', category: health, countries: ['ES']
+    @wikipedia = create_project name: 'Wikipedia', countries: ['ES']
+
+    create_donation project: @cruz_roja, quantity: 20, date: Date.today, user: @user, quantity_privacy: true
+    create_donation project: @cruz_roja, quantity: 30, date: Date.today, user: @other_user
+    create_donation project: @wikipedia, quantity: 10, date: Date.today, user: @other_user, quantity_privacy: true
+
   end
 
   scenario 'I should be able to filter by Alphabetic order' do
@@ -27,6 +36,12 @@ RSpec.feature 'Projects navigation' do
     expect(page).to have_css(".project:nth-child(2) a", text: "Wikipedia")
     expect(page).to have_css(".project:nth-child(3) a", text: "Médicos Sin Fronteras")
     expect(page).to have_css(".project:nth-child(4) a", text: "Cruz Roja")
+
+    click_link "Popular"
+
+    expect(page).to have_css(".project:nth-child(2) a", text: "Cruz Roja")
+    expect(page).to have_css(".project:nth-child(3) a", text: "Wikipedia")
+    expect(page).to have_css(".project:nth-child(4) a", text: "Médicos Sin Fronteras")
   end
 
   scenario 'I should be able to filter by Category' do


### PR DESCRIPTION
Now "sort by" links in the project list works correctly once selected a sorting value different than default.

At **projects_helper.rb** line 34 the code was adding to the url the current **:sort_by** value from **params[:sort_by]** ignoring if it was actually getting a value for **:sort_by** in the **extra_params** parameter.

PD: Thank you and congrats for this project! #141 