### PR TITLE
Fix #143 the TrackDon modal was popping whenever you press enter in a form

### DIFF
--- a/app/assets/javascripts/modules/modal.js
+++ b/app/assets/javascripts/modules/modal.js
@@ -45,11 +45,13 @@ jQuery(document).ready(function($){
   });
 
   // Prevent Enter key to click on the first button of the form, which is the link to the
-  // other form
+  // other form only when the trackdon modal form is visible
   $(document).keydown(function(event){
     if(event.which=='13'){
-      event.preventDefault();
-      $('form:visible').submit();
+      if( $('form[id="new_donation"]').parents("#modal-track").hasClass('.is-visible') ){
+        event.preventDefault();
+        $('form:visible').submit();
+      }
     }
   });
 


### PR DESCRIPTION
This closes issue #143. The enter key was being capture to prevent any form from being submitted except from the Track Donation modal form.

Now we check if the modal form is visible first.